### PR TITLE
Add quotes so it's valid YAML on php7.2

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -54,7 +54,7 @@ reflar-usermanagement:
         previous: "{username}'s Previous Record"
     modal:
       post:
-        title: Serve a Strike to: {username}
+        title: "Serve a Strike to: {username}"
         reason_placeholder: Reason for strike
         strike_reason: Reason
         submit_button: Serve Strike


### PR DESCRIPTION
Without you'll get a page saying something is broken when using php7.2 
Should also fix #27 